### PR TITLE
make topbar switcher

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -62,8 +62,14 @@ const config = {
         items: [
           {
             position: 'left',
-            html: '<div><div class="custom-tag">Python</div><div class="custom-tag">Javascript</div></div>',
-            href: '#',
+            html: '<div><div class="custom-tag">Python</div></div>',
+            href: '?lang=py',
+            docId: "blah"
+          },
+          {
+            position: 'left',
+            html: '<div><div class="custom-tag">Javascript</div></div>',
+            href: '?lang=js',
             docId: "blah"
           },
           {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -529,12 +529,17 @@ div.special_table + table, th, td {
 }
 
 .custom-tag:hover {
-  cursor: default;
-  color: #000;
+  background-color: #e5e5e5;
 }
 
 .select-language {
   font-size: 1em;
   font-weight: bolder;
   margin-bottom: 8px;
+}
+
+.navbar__link:has(div.custom-tag) {
+  padding: 0px;
+  margin: 0px;
+  margin-left: 5px;
 }


### PR DESCRIPTION
<img width="664" alt="Screenshot 2023-02-27 at 8 29 23 PM" src="https://user-images.githubusercontent.com/891664/221754178-22a0d2a3-2778-459f-85c8-45a5f5505a5c.png">

This PR makes the topbar buttons for `python` and `javascript` actually change the mode for the site between languages. 