### PR TITLE
Add Render to Deployment

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,13 @@ remotely.
 
 There are many possible configurations, but for convenience we have
 provided a very simple AWS CloudFormation template to experiment with
-deploying Chroma to EC2 on AWS.
+deploying Chroma to EC2 on AWS as well as a single button deployment
+for Render
+
+## Render
+<a href="https://render.com/deploy?repo=https://github.com/chroma-core/chroma">
+<img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render">
+</a>
 
 ## Simple AWS Deployment
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,7 +15,7 @@ for Render
 
 ## Render
 <a href="https://render.com/deploy?repo=https://github.com/chroma-core/chroma">
-<img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render">
+<img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render"/>
 </a>
 
 ## Simple AWS Deployment


### PR DESCRIPTION
This is related to https://github.com/chroma-core/chroma/pull/218

It links to the chroma-core/chroma repo, which is appropriate if the above PR is merged. If you don't want the above PR but are still interested in this button, you could point the link to https://github.com/ericmand/render-chroma which does the same thing. I put the link above AWS because the instructions are so much shorter but you could move below if you prefer.