### PR TITLE
add extra info about calling .persist manually for jupyter notebooks

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -42,6 +42,9 @@ client = chromadb.Client(Settings(chroma_db_impl="duckdb+parquet",
                                 ))
 ```
 
+If you are using a Jupyter Notebook, you will need to call `client.persist()` manually.
+
+
 ### Run chroma just as a client to talk to a backend service
 
 For production use cases, an in-memory database will not cut it. Run `docker-compose up -d --build` to run a production backend in Docker on your local computer. Simply update your API initialization and then use the API the same way as before.

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -39,6 +39,10 @@ client = chromadb.Client(Settings(
 
 The `persist_directory` is where Chroma will store its database files on disk, and load them on start.
 
+:::note Jupyter Notebook Usage
+If you are using a Jupyter Notebook, you will need to call `client.persist()` manually because of the way that Jupyter's garbage collection works. 
+:::
+
 </TabItem>
 <TabItem value="js" label="JavaScript">
 


### PR DESCRIPTION
Add notes on calling `.persist` in notebook contexts. 