### PR TITLE
fix py and js doc links; RetrievalQAChain supersedes ChatVectorDBQAChain

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -28,7 +28,7 @@ import TabItem from '@theme/TabItem';
 - Tutorials
   - [Chroma and LangChain tutorial](https://github.com/grumpyp/chroma-langchain-tutorial) - The demo showcases how to pull data from the English Wikipedia using their API. The project also demonstrates how to vectorize data in chunks and get embeddings using OpenAI embeddings model.
   - [Create a Voice-based ChatGPT Clone That Can Search on the Internet and local files](https://betterprogramming.pub/how-to-create-a-voice-based-chatgpt-clone-that-can-search-on-the-internet-24d7f570ea8)
-- [LangChain's Chroma Documentation](https://langchain.readthedocs.io/en/latest/reference/modules/vectorstore.html?highlight=chroma#langchain.vectorstores.Chroma)
+- [LangChain's Chroma Documentation](https://python.langchain.com/en/latest/modules/indexes/vectorstores.html?highlight=chroma#langchain.vectorstores.Chroma)
 
 ## 🦙 LlamaIndex
 
@@ -49,7 +49,7 @@ Here is an [example in LangChainJS](https://github.com/hwchase17/langchainjs/blo
 
 ```javascript
 import { OpenAI } from "langchain/llms";
-import { ChatVectorDBQAChain } from "langchain/chains";
+import { ConversationalRetrievalQAChain } from "langchain/chains";
 import { Chroma } from "langchain/vectorstores";
 import { OpenAIEmbeddings } from "langchain/embeddings";
 import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
@@ -72,7 +72,7 @@ export const run = async () => {
     { collectionName: "state_of_the_union" }
   );
   /* Create the chain */
-  const chain = ChatVectorDBQAChain.fromLLM(model, vectorStore);
+  const chain = ConversationalRetrievalQAChain.fromLLM(model, vectorStore.asRetriever());
   /* Ask it a question */
   const question = "What did the president say about Justice Breyer?";
   const res = await chain.call({ question, chat_history: [] });
@@ -80,6 +80,7 @@ export const run = async () => {
 };
 ```
 
+- [LangChainJS Chroma Documentation](https://js.langchain.com/docs/modules/indexes/vector_stores/integrations/chroma)
 
 </TabItem>
 

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -48,10 +48,10 @@ import TabItem from '@theme/TabItem';
 Here is an [example in LangChainJS](https://github.com/hwchase17/langchainjs/blob/main/examples/src/chains/chat_vector_db_chroma.ts)
 
 ```javascript
-import { OpenAI } from "langchain/llms";
+import { OpenAI } from "langchain/llms/openai";
 import { ConversationalRetrievalQAChain } from "langchain/chains";
-import { Chroma } from "langchain/vectorstores";
-import { OpenAIEmbeddings } from "langchain/embeddings";
+import { Chroma } from "langchain/vectorstores/chroma";
+import { OpenAIEmbeddings } from "langchain/embeddings/openai";
 import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
 import * as fs from "fs";
 


### PR DESCRIPTION
see index abstraction: https://github.com/hwchase17/langchainjs/commit/be32ed0d663d623affff4614cbedf5a31e286f2e