### PR TITLE
Update instructions to use pre-built docker images

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,6 +78,7 @@ cd chroma
 docker-compose up -d --build
 ```
 
+Refer to [this docker-compose file](https://github.com/chroma-core/chroma/blob/main/docker-compose.yml) for environment variables and other dependencies (eg: [clickhouse](https://clickhouse.com)).
 If you have build issues, please reach out for help in the active [Community Discord](https://discord.gg/MMeYNTmh3x). Most issues get fixed in a few minutes.
 
 ### 3. Create a collection

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,7 +59,18 @@ const {ChromaClient} = require('chromadb');
 const client = new ChromaClient();
 ```
 
-To connect to Chroma's backend - you either need to connect to a hosted version of Chroma, or run it on your local computer. If you can run `docker-compose up -d --build` you can run Chroma. 
+</TabItem>
+
+</Tabs>
+
+To connect to Chroma's backend - you either need to connect to a hosted version of Chroma, or run it on your local computer.
+You can pull pre-built image using
+
+```bash
+docker pull ghcr.io/chroma-core/chroma:latest
+```
+
+or you can build the container from source using
 
 ```bash
 git clone https://github.com/chroma-core/chroma.git
@@ -68,10 +79,6 @@ docker-compose up -d --build
 ```
 
 If you have build issues, please reach out for help in the active [Community Discord](https://discord.gg/MMeYNTmh3x). Most issues get fixed in a few minutes.
-
-</TabItem>
-
-</Tabs>
 
 ### 3. Create a collection
 


### PR DESCRIPTION
1. Updates instructions on how to use pre-built docker images from `ghcr`
2. Show how to use docker for both `py` and `js`

<img width="781" alt="Screenshot 2023-06-08 at 12 12 11 am" src="https://github.com/chroma-core/docs/assets/6940024/6f2c44db-b536-4c65-992b-cdd6942414f0">
<img width="733" alt="Screenshot 2023-06-08 at 12 12 19 am" src="https://github.com/chroma-core/docs/assets/6940024/b3768ce1-44ff-4c81-8ae8-6fc75766bddb">
