### PR TITLE
add troubleshooting for embeddings being None

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,9 +5,29 @@ title: "🔍 Troubleshooting"
 
 # 🔍 Troubleshooting
 
-This page is a list of common gotchas or issues and how to fix them! 
+This page is a list of common gotchas or issues and how to fix them.
 
 If you don't see your problem listed here, please also search the [Github Issues](https://github.com/chroma-core/chroma/issues).
+
+
+## Using .get or .query, embeddings say `None`
+
+This is actually not an error. Embeddings are quite large and heavy to send back. Most application don't use the underlying embeddings and so, by default, chroma does not send them back. 
+
+To send them back: add `include=["embeddings", "documents", "metadatas", "distances"]` to your query to return all information.
+
+For example:
+```python
+results = collection.query(
+    query_texts="hello",
+    n_results=1,
+    include=["embeddings", "documents", "metadatas", "distances"],
+)
+```
+
+:::note
+We may change `None` to something else to more clearly communicate why they were not returned.
+:::
 
 
 ## Your index resets back to just a few number of records
@@ -26,3 +46,6 @@ Here is what commonly happens.
 
 `Solution`: Don't keep multiple `in-memory` clients alive at once. 
 
+:::note
+We may add extra logic to warn if multiple in-memory clients are used with the same path.
+:::


### PR DESCRIPTION
This adds a troubleshooting section for `embeddings=None` which is a common thing users raise. 