### PR TITLE
fix header styling on python api docs, closes #63

### DIFF
--- a/docs/reference/Collection.md
+++ b/docs/reference/Collection.md
@@ -4,13 +4,13 @@ title: Collection
 sidebar_position: 2
 ---
 
-## Collection Objects
+# Collection Objects
 
 ```python
 class Collection(BaseModel)
 ```
 
-#### count
+### count
 
 ```python
 def count() -> int
@@ -22,7 +22,7 @@ The total number of embeddings added to the database
 
 - `int` - The total number of embeddings added to the database
 
-#### add
+### add
 
 ```python
 def add(ids: OneOrMany[ID],
@@ -56,7 +56,7 @@ Add embeddings to the data store.
 - `ValueError` - If you provide both embeddings and documents
 - `ValueError` - If you provide an id that already exists
 
-#### get
+### get
 
 ```python
 def get(ids: Optional[OneOrMany[ID]] = None,
@@ -76,7 +76,7 @@ all embeddings up to limit starting at offset.
 - `where` - A Where type dict used to filter results by. E.g. `{"color" : "red", "price": 4.20}`. Optional.
 - `limit` - The number of documents to return. Optional.
 - `offset` - The offset to start returning results from. Useful for paging results with limit. Optional.
-- `where_document` - A WhereDocument type dict used to filter by the documents. E.g. `{$contains: {"text": "hello"}}`. Optional.
+- `where_document` - A WhereDocument type dict used to filter by the documents. E.g. `{$contains: "some text"}`. Optional.
 - `include` - A list of what to include in the results. Can contain `"embeddings"`, `"metadatas"`, `"documents"`. Ids are always included. Defaults to `["metadatas", "documents"]`. Optional.
   
 
@@ -84,7 +84,7 @@ all embeddings up to limit starting at offset.
 
 - `GetResult` - A GetResult object containing the results.
 
-#### peek
+### peek
 
 ```python
 def peek(limit: int = 10) -> GetResult
@@ -101,7 +101,7 @@ Get the first few results in the database up to limit
 
 - `GetResult` - A GetResult object containing the results.
 
-#### query
+### query
 
 ```python
 def query(
@@ -120,9 +120,9 @@ Get the n_results nearest neighbor embeddings for provided query_embeddings or q
 
 - `query_embeddings` - The embeddings to get the closes neighbors of. Optional.
 - `query_texts` - The document texts to get the closes neighbors of. Optional.
-- `n_results` - The number of neighbors to return for each query_embedding or query_text. Optional.
+- `n_results` - The number of neighbors to return for each query_embedding or query_texts. Optional.
 - `where` - A Where type dict used to filter results by. E.g. `{"color" : "red", "price": 4.20}`. Optional.
-- `where_document` - A WhereDocument type dict used to filter by the documents. E.g. `{"$contains": "some text"}`. Optional.
+- `where_document` - A WhereDocument type dict used to filter by the documents. E.g. `{$contains: "some text"}`. Optional.
 - `include` - A list of what to include in the results. Can contain `"embeddings"`, `"metadatas"`, `"documents"`, `"distances"`. Ids are always included. Defaults to `["metadatas", "documents", "distances"]`. Optional.
   
 
@@ -136,11 +136,11 @@ Get the n_results nearest neighbor embeddings for provided query_embeddings or q
 - `ValueError` - If you don't provide either query_embeddings or query_texts
 - `ValueError` - If you provide both query_embeddings and query_texts
 
-#### modify
+### modify
 
 ```python
 def modify(name: Optional[str] = None,
-           metadata: Optional[Metadata] = None) -> None
+           metadata: Optional[CollectionMetadata] = None) -> None
 ```
 
 Modify the collection name or metadata
@@ -155,7 +155,7 @@ Modify the collection name or metadata
 
   None
 
-#### update
+### update
 
 ```python
 def update(ids: OneOrMany[ID],
@@ -178,7 +178,7 @@ Update the embeddings, metadatas or documents for provided ids.
 
   None
 
-#### upsert
+### upsert
 
 ```python
 def upsert(ids: OneOrMany[ID],
@@ -196,13 +196,18 @@ Update the embeddings, metadatas or documents for provided ids, or create them i
 - `embeddings` - The embeddings to add. If None, embeddings will be computed based on the documents using the embedding_function set for the Collection. Optional.
 - `metadatas` - The metadata to associate with the embeddings. When querying, you can filter on this metadata. Optional.
 - `documents` - The documents to associate with the embeddings. Optional.
+  
 
-#### delete
+**Returns**:
+
+  None
+
+### delete
 
 ```python
 def delete(ids: Optional[IDs] = None,
            where: Optional[Where] = None,
-           where_document: Optional[WhereDocument] = None) -> List[str]
+           where_document: Optional[WhereDocument] = None) -> None
 ```
 
 Delete the embeddings based on ids and/or a where filter
@@ -211,7 +216,7 @@ Delete the embeddings based on ids and/or a where filter
 
 - `ids` - The ids of the embeddings to delete
 - `where` - A Where type dict used to filter the delection by. E.g. `{"color" : "red", "price": 4.20}`. Optional.
-- `where_document` - A WhereDocument type dict used to filter the deletion by the document content. E.g. `{$contains: {"text": "hello"}}`. Optional.
+- `where_document` - A WhereDocument type dict used to filter the deletion by the document content. E.g. `{$contains: "some text"}`. Optional.
   
 
 **Returns**:

--- a/docs/reference/local.md
+++ b/docs/reference/local.md
@@ -4,13 +4,13 @@ title: Client
 sidebar_position: 1
 ---
 
-## LocalAPI Objects
+# LocalAPI Objects
 
 ```python
 class LocalAPI(API)
 ```
 
-#### heartbeat
+### heartbeat
 
 ```python
 def heartbeat() -> int
@@ -22,12 +22,13 @@ Ping the database to ensure it is alive
 
   The current time in milliseconds
 
-#### create\_collection
+### create\_collection
 
 ```python
 def create_collection(name: str,
-                      metadata: Optional[Metadata] = None,
-                      embedding_function: Optional[Callable] = None,
+                      metadata: Optional[CollectionMetadata] = None,
+                      embedding_function: Optional[EmbeddingFunction] = ef.
+                      DefaultEmbeddingFunction(),
                       get_or_create: bool = False) -> Collection
 ```
 
@@ -62,13 +63,15 @@ Create a new collection with the given name and metadata.
   # collection(name="my_collection", metadata={"foo": "bar"})
   ```
 
-#### get\_or\_create\_collection
+### get\_or\_create\_collection
 
 ```python
 def get_or_create_collection(
-        name: str,
-        metadata: Optional[Metadata] = None,
-        embedding_function: Optional[Callable] = None) -> Collection
+    name: str,
+    metadata: Optional[CollectionMetadata] = None,
+    embedding_function: Optional[EmbeddingFunction] = ef.
+    DefaultEmbeddingFunction()
+) -> Collection
 ```
 
 Get or create a collection with the given name and metadata.
@@ -92,12 +95,14 @@ Get or create a collection with the given name and metadata.
   # collection(name="my_collection", metadata={})
   ```
 
-#### get\_collection
+### get\_collection
 
 ```python
 def get_collection(
-        name: str,
-        embedding_function: Optional[Callable] = None) -> Collection
+    name: str,
+    embedding_function: Optional[EmbeddingFunction] = ef.
+    DefaultEmbeddingFunction()
+) -> Collection
 ```
 
 Get a collection with the given name.
@@ -125,7 +130,7 @@ Get a collection with the given name.
   # collection(name="my_collection", metadata={})
   ```
 
-#### list\_collections
+### list\_collections
 
 ```python
 def list_collections() -> Sequence[Collection]
@@ -145,7 +150,7 @@ List all collections.
   # [collection(name="my_collection", metadata={})]
   ```
 
-#### delete\_collection
+### delete\_collection
 
 ```python
 def delete_collection(name: str) -> None
@@ -169,10 +174,10 @@ Delete a collection with the given name.
   client.delete_collection("my_collection")
   ```
 
-#### reset
+### reset
 
 ```python
-def reset() -> bool
+def reset() -> None
 ```
 
 Reset the database. This will delete all collections and items.
@@ -181,7 +186,7 @@ Reset the database. This will delete all collections and items.
 
   True if the database was reset successfully
 
-#### persist
+### persist
 
 ```python
 def persist() -> bool
@@ -193,7 +198,7 @@ Persist the database to disk.
 
   True if the database was persisted successfully
 
-#### get\_version
+### get\_version
 
 ```python
 def get_version() -> str

--- a/scripts/pythonDocs.sh
+++ b/scripts/pythonDocs.sh
@@ -53,5 +53,16 @@ fi
 # Create an empty backup file for compatibility with macOS/BSD sed
 sed -i.bak -e ':a' -e 'N' -e '$!ba' -e 's/---\n.*\n---/'"$new_section2"'/g' "$file2"
 
+# find all examples of "## " inside Collection.md and replace it with "# "
+sed -i.bak -e 's/## /# /g' "$file2"
+sed -i.bak -e 's/#### /### /g' "$file2"
+
+sed -i.bak -e 's/## /# /g' "$file"
+sed -i.bak -e 's/#### /### /g' "$file"
+
+# remove @override 
+sed -i.bak -e '/@override/d' "$file"
+
 # Remove the backup file
 rm "${file2}.bak"
+rm "${file}.bak"


### PR DESCRIPTION
updates autogen python docs to use different markdown headers so they show up in the sidebar