### PR TITLE
Fixed description of using Azure with Embeddings.

### DIFF
--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -80,8 +80,10 @@ openai_ef = embedding_functions.OpenAIEmbeddingFunction(
             )
 ```
 
-To use the OpenAI embedding models on other platforms such as Azure, you can use the `api_base` and `api_type` parameters: 
+To use the OpenAI embedding models on other platforms such as Azure, you can use the `api_base` and `api_type` parameters:  
+Moreover, the version must be specified in the environment variable `OPENAI_API_VERSION`.
 ```python
+os.environ['OPENAI_API_VERSION'] = '2023-05-15'
 openai_ef = embedding_functions.OpenAIEmbeddingFunction(
                 api_key="YOUR_API_KEY",
                 api_base="YOUR_API_BASE_PATH",


### PR DESCRIPTION
# Overview
When using Embeddings in Azure, the `OPENAI_API_VERSION` environment variable had to be specified in addition to the information in the documentation.
Update documentation.

# Changes
- Added description of environment variables
- Added example of environment variable setting to sample code

# Note
- Messages with unspecified environment variables are as follows
```
packages\openai\api_resources\abstract\engine_api_resource.py", line 37, in class_url       
    raise error.InvalidRequestError(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: InvalidRequestError.__init__() missing 1 required positional argument: 'param'
```