### PR TITLE
small typo and change old link for llama integration

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -103,7 +103,7 @@ The CloudFormation template allows you to pass particular key/value
 pairs to override aspects of the stack. Available keys are:
 
 - `InstanceType` - the AWS instance type to run (default: `t3.small`)
-- `KeyName` - the AWS EC2 KeyPair to use, allowing to to access the instance via SSH (default: none)
+- `KeyName` - the AWS EC2 KeyPair to use, allowing to access the instance via SSH (default: none)
 
 To set a CloudFormation stack's parameters using the AWS CLI, use the
 `--parameters` command line option. Parameters must be specified using

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -35,7 +35,7 @@ import TabItem from '@theme/TabItem';
 > *formerly known as GPT-index*
 
 - `LlamaIndex` [Vector Store page](https://gpt-index.readthedocs.io/en/latest/how_to/integrations/vector_stores.html)
-- Demo: https://github.com/jerryjliu/llama_index/blob/main/examples/vector_indices/ChromaIndexDemo.ipynb
+- Demo: https://github.com/jerryjliu/llama_index/blob/main/docs/examples/vector_stores/ChromaIndexDemo.ipynb
 - [Chroma Loader on Llamahub](https://llamahub.ai/l/chroma)
 
 


### PR DESCRIPTION
Just a small typo in deployment docs
llama index moved all there docs into docs folder so the link changed