### PR TITLE
Fix where examples in reference

### DIFF
--- a/docs/js_reference/Collection.md
+++ b/docs/js_reference/Collection.md
@@ -12,13 +12,13 @@ sidebar_position: 2
 
 • **id**: `string`
 
-___
+---
 
 ### metadata
 
 • **metadata**: `undefined` \| `CollectionMetadata`
 
-___
+---
 
 ### name
 
@@ -37,21 +37,24 @@ Add items to the collection
 ```typescript
 const response = await collection.add({
   ids: ["id1", "id2"],
-  embeddings: [[1, 2, 3], [4, 5, 6]],
-  metadatas: [{ "key": "value" }, { "key": "value" }],
-  documents: ["document1", "document2"]
+  embeddings: [
+    [1, 2, 3],
+    [4, 5, 6],
+  ],
+  metadatas: [{ key: "value" }, { key: "value" }],
+  documents: ["document1", "document2"],
 });
 ```
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `params` | `Object` | The parameters for the query. |
-| `params.documents?` | `string` \| `Documents` | Optional documents of the items to add. |
+| Name                 | Type                        | Description                              |
+| :------------------- | :-------------------------- | :--------------------------------------- |
+| `params`             | `Object`                    | The parameters for the query.            |
+| `params.documents?`  | `string` \| `Documents`     | Optional documents of the items to add.  |
 | `params.embeddings?` | `Embedding` \| `Embeddings` | Optional embeddings of the items to add. |
-| `params.ids` | `string` \| `IDs` | IDs of the items to add. |
-| `params.metadatas?` | `Metadata` \| `Metadatas` | Optional metadata of the items to add. |
+| `params.ids`         | `string` \| `IDs`           | IDs of the items to add.                 |
+| `params.metadatas?`  | `Metadata` \| `Metadatas`   | Optional metadata of the items to add.   |
 
 #### Returns
 
@@ -59,7 +62,7 @@ const response = await collection.add({
 
 - The response from the API. True if successful.
 
-___
+---
 
 ### count
 
@@ -79,7 +82,7 @@ const response = await collection.count();
 
 - The response from the API.
 
-___
+---
 
 ### delete
 
@@ -96,19 +99,19 @@ If there is an issue deleting items from the collection.
 ```typescript
 const results = await collection.delete({
   ids: "some_id",
-  where: {"name": {"$eq": "John Doe"}},
+  where: {"$and": ["name": {"$eq": "John Doe"}, "age": {"$gte": 30}]},
   whereDocument: {"$contains":"search_string"}
 });
 ```
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `params` | `Object` | The parameters for deleting items from the collection. |
-| `params.ids?` | `string` \| `IDs` | Optional ID or array of IDs of items to delete. |
-| `params.where?` | `Where` | Optional query condition to filter items to delete based on metadata values. |
-| `params.whereDocument?` | `WhereDocument` | Optional query condition to filter items to delete based on document content. |
+| Name                    | Type              | Description                                                                   |
+| :---------------------- | :---------------- | :---------------------------------------------------------------------------- |
+| `params`                | `Object`          | The parameters for deleting items from the collection.                        |
+| `params.ids?`           | `string` \| `IDs` | Optional ID or array of IDs of items to delete.                               |
+| `params.where?`         | `Where`           | Optional query condition to filter items to delete based on metadata values.  |
+| `params.whereDocument?` | `WhereDocument`   | Optional query condition to filter items to delete based on document content. |
 
 #### Returns
 
@@ -116,7 +119,7 @@ const results = await collection.delete({
 
 A promise that resolves to the IDs of the deleted items.
 
-___
+---
 
 ### get
 
@@ -129,7 +132,7 @@ Get items from the collection
 ```typescript
 const response = await collection.get({
   ids: ["id1", "id2"],
-  where: { "key": "value" },
+  where: { key: "value" },
   limit: 10,
   offset: 0,
   include: ["embeddings", "metadatas", "documents"],
@@ -139,15 +142,15 @@ const response = await collection.get({
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `params` | `Object` | The parameters for the query. |
-| `params.ids?` | `string` \| `IDs` | Optional IDs of the items to get. |
-| `params.include?` | `IncludeEnum`[] | Optional list of items to include in the response. |
-| `params.limit?` | `number` | Optional limit on the number of items to get. |
-| `params.offset?` | `number` | Optional offset on the items to get. |
-| `params.where?` | `Where` | Optional where clause to filter items by. |
-| `params.whereDocument?` | `WhereDocument` | Optional where clause to filter items by. |
+| Name                    | Type              | Description                                        |
+| :---------------------- | :---------------- | :------------------------------------------------- |
+| `params`                | `Object`          | The parameters for the query.                      |
+| `params.ids?`           | `string` \| `IDs` | Optional IDs of the items to get.                  |
+| `params.include?`       | `IncludeEnum`[]   | Optional list of items to include in the response. |
+| `params.limit?`         | `number`          | Optional limit on the number of items to get.      |
+| `params.offset?`        | `number`          | Optional offset on the items to get.               |
+| `params.where?`         | `Where`           | Optional where clause to filter items by.          |
+| `params.whereDocument?` | `WhereDocument`   | Optional where clause to filter items by.          |
 
 #### Returns
 
@@ -155,7 +158,7 @@ const response = await collection.get({
 
 - The response from the server.
 
-___
+---
 
 ### modify
 
@@ -168,17 +171,17 @@ Modify the collection name or metadata
 ```typescript
 const response = await collection.modify({
   name: "new name",
-  metadata: { "key": "value" },
+  metadata: { key: "value" },
 });
 ```
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `params` | `Object` | The parameters for the query. |
+| Name               | Type                 | Description                               |
+| :----------------- | :------------------- | :---------------------------------------- |
+| `params`           | `Object`             | The parameters for the query.             |
 | `params.metadata?` | `CollectionMetadata` | Optional new metadata for the collection. |
-| `params.name?` | `string` | Optional new name for the collection. |
+| `params.name?`     | `string`             | Optional new name for the collection.     |
 
 #### Returns
 
@@ -186,7 +189,7 @@ const response = await collection.modify({
 
 - The response from the API.
 
-___
+---
 
 ### peek
 
@@ -202,15 +205,15 @@ If there is an issue executing the query.
 
 ```typescript
 const results = await collection.peek({
-  limit: 10
+  limit: 10,
 });
 ```
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `params` | `Object` | The parameters for the query. |
+| Name            | Type     | Description                                           |
+| :-------------- | :------- | :---------------------------------------------------- |
+| `params`        | `Object` | The parameters for the query.                         |
 | `params.limit?` | `number` | Optional number of results to return (default is 10). |
 
 #### Returns
@@ -219,7 +222,7 @@ const results = await collection.peek({
 
 A promise that resolves to the query results.
 
-___
+---
 
 ### query
 
@@ -238,7 +241,7 @@ If there is an issue executing the query.
 const results = await collection.query({
   queryEmbeddings: [[0.1, 0.2, ...], ...],
   nResults: 10,
-  where: {"name": {"$eq": "John Doe"}},
+  where: {"$and": ["name": {"$eq": "John Doe"}, "age": {"$gte": 30}]},
   include: ["metadata", "document"]
 });
 ```
@@ -250,22 +253,22 @@ const results = await collection.query({
 const results = await collection.query({
   queryTexts: "some text",
   nResults: 10,
-  where: {"name": {"$eq": "John Doe"}},
-  include: ["metadata", "document"]
+  where: { $and: [("name": { $eq: "John Doe" }), ("age": { $gte: 30 })] },
+  include: ["metadata", "document"],
 });
 ```
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `params` | `Object` | The parameters for the query. |
-| `params.include?` | `IncludeEnum`[] | Optional array of fields to include in the result, such as "metadata" and "document". |
-| `params.nResults?` | `number` | Optional number of results to return (default is 10). |
-| `params.queryEmbeddings?` | `Embedding` \| `Embeddings` | Optional query embeddings to use for the search. |
-| `params.queryTexts?` | `string` \| `string`[] | Optional query text(s) to search for in the collection. |
-| `params.where?` | `Where` | Optional query condition to filter results based on metadata values. |
-| `params.whereDocument?` | `WhereDocument` | Optional query condition to filter results based on document content. |
+| Name                      | Type                        | Description                                                                           |
+| :------------------------ | :-------------------------- | :------------------------------------------------------------------------------------ |
+| `params`                  | `Object`                    | The parameters for the query.                                                         |
+| `params.include?`         | `IncludeEnum`[]             | Optional array of fields to include in the result, such as "metadata" and "document". |
+| `params.nResults?`        | `number`                    | Optional number of results to return (default is 10).                                 |
+| `params.queryEmbeddings?` | `Embedding` \| `Embeddings` | Optional query embeddings to use for the search.                                      |
+| `params.queryTexts?`      | `string` \| `string`[]      | Optional query text(s) to search for in the collection.                               |
+| `params.where?`           | `Where`                     | Optional query condition to filter results based on metadata values.                  |
+| `params.whereDocument?`   | `WhereDocument`             | Optional query condition to filter results based on document content.                 |
 
 #### Returns
 
@@ -273,7 +276,7 @@ const results = await collection.query({
 
 A promise that resolves to the query results.
 
-___
+---
 
 ### update
 
@@ -286,21 +289,24 @@ Update the embeddings, documents, and/or metadatas of existing items
 ```typescript
 const response = await collection.update({
   ids: ["id1", "id2"],
-  embeddings: [[1, 2, 3], [4, 5, 6]],
-  metadatas: [{ "key": "value" }, { "key": "value" }],
+  embeddings: [
+    [1, 2, 3],
+    [4, 5, 6],
+  ],
+  metadatas: [{ key: "value" }, { key: "value" }],
   documents: ["new document 1", "new document 2"],
 });
 ```
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `params` | `Object` | The parameters for the query. |
-| `params.documents?` | `string` \| `Documents` | Optional documents to update. |
-| `params.embeddings?` | `Embedding` \| `Embeddings` | Optional embeddings to update. |
-| `params.ids` | `string` \| `IDs` | The IDs of the items to update. |
-| `params.metadatas?` | `Metadata` \| `Metadatas` | Optional metadatas to update. |
+| Name                 | Type                        | Description                     |
+| :------------------- | :-------------------------- | :------------------------------ |
+| `params`             | `Object`                    | The parameters for the query.   |
+| `params.documents?`  | `string` \| `Documents`     | Optional documents to update.   |
+| `params.embeddings?` | `Embedding` \| `Embeddings` | Optional embeddings to update.  |
+| `params.ids`         | `string` \| `IDs`           | The IDs of the items to update. |
+| `params.metadatas?`  | `Metadata` \| `Metadatas`   | Optional metadatas to update.   |
 
 #### Returns
 
@@ -308,7 +314,7 @@ const response = await collection.update({
 
 - The API Response. True if successful. Else, error.
 
-___
+---
 
 ### upsert
 
@@ -321,21 +327,24 @@ Upsert items to the collection
 ```typescript
 const response = await collection.upsert({
   ids: ["id1", "id2"],
-  embeddings: [[1, 2, 3], [4, 5, 6]],
-  metadatas: [{ "key": "value" }, { "key": "value" }],
+  embeddings: [
+    [1, 2, 3],
+    [4, 5, 6],
+  ],
+  metadatas: [{ key: "value" }, { key: "value" }],
   documents: ["document1", "document2"],
 });
 ```
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `params` | `Object` | The parameters for the query. |
-| `params.documents?` | `string` \| `Documents` | Optional documents of the items to add. |
+| Name                 | Type                        | Description                              |
+| :------------------- | :-------------------------- | :--------------------------------------- |
+| `params`             | `Object`                    | The parameters for the query.            |
+| `params.documents?`  | `string` \| `Documents`     | Optional documents of the items to add.  |
 | `params.embeddings?` | `Embedding` \| `Embeddings` | Optional embeddings of the items to add. |
-| `params.ids` | `string` \| `IDs` | IDs of the items to add. |
-| `params.metadatas?` | `Metadata` \| `Metadatas` | Optional metadata of the items to add. |
+| `params.ids`         | `string` \| `IDs`           | IDs of the items to add.                 |
+| `params.metadatas?`  | `Metadata` \| `Metadatas`   | Optional metadata of the items to add.   |
 
 #### Returns
 

--- a/docs/reference/Collection.md
+++ b/docs/reference/Collection.md
@@ -40,12 +40,10 @@ Add embeddings to the data store.
 - `metadata` - The metadata to associate with the embeddings. When querying, you can filter on this metadata. Optional.
 - `documents` - The documents to associate with the embeddings. Optional.
 - `ids` - The ids to associate with the embeddings. Optional.
-  
 
 **Returns**:
 
-  None
-  
+None
 
 **Raises**:
 
@@ -72,12 +70,11 @@ all embeddings up to limit starting at offset.
 **Arguments**:
 
 - `ids` - The ids of the embeddings to get. Optional.
-- `where` - A Where type dict used to filter results by. E.g. `{"color" : "red", "price": 4.20}`. Optional.
+- `where` - A Where type dict used to filter results by. E.g. `{"$and": ["color" : "red", "price": {"$gte": 4.20}]}`. Optional.
 - `limit` - The number of documents to return. Optional.
 - `offset` - The offset to start returning results from. Useful for paging results with limit. Optional.
 - `where_document` - A WhereDocument type dict used to filter by the documents. E.g. `{$contains: "some text"}`. Optional.
 - `include` - A list of what to include in the results. Can contain `"embeddings"`, `"metadatas"`, `"documents"`. Ids are always included. Defaults to `["metadatas", "documents"]`. Optional.
-  
 
 **Returns**:
 
@@ -94,7 +91,6 @@ Get the first few results in the database up to limit
 **Arguments**:
 
 - `limit` - The number of results to return.
-  
 
 **Returns**:
 
@@ -120,15 +116,13 @@ Get the n_results nearest neighbor embeddings for provided query_embeddings or q
 - `query_embeddings` - The embeddings to get the closes neighbors of. Optional.
 - `query_texts` - The document texts to get the closes neighbors of. Optional.
 - `n_results` - The number of neighbors to return for each query_embedding or query_texts. Optional.
-- `where` - A Where type dict used to filter results by. E.g. `{"color" : "red", "price": 4.20}`. Optional.
+- `where` - A Where type dict used to filter results by. E.g. `{"$and": ["color" : "red", "price": {"$gte": 4.20}]}`. Optional.
 - `where_document` - A WhereDocument type dict used to filter by the documents. E.g. `{$contains: "some text"}`. Optional.
 - `include` - A list of what to include in the results. Can contain `"embeddings"`, `"metadatas"`, `"documents"`, `"distances"`. Ids are always included. Defaults to `["metadatas", "documents", "distances"]`. Optional.
-  
 
 **Returns**:
 
 - `QueryResult` - A QueryResult object containing the results.
-  
 
 **Raises**:
 
@@ -148,11 +142,10 @@ Modify the collection name or metadata
 
 - `name` - The updated name for the collection. Optional.
 - `metadata` - The updated metadata for the collection. Optional.
-  
 
 **Returns**:
 
-  None
+None
 
 ### update
 
@@ -171,11 +164,10 @@ Update the embeddings, metadatas or documents for provided ids.
 - `embeddings` - The embeddings to add. If None, embeddings will be computed based on the documents using the embedding_function set for the Collection. Optional.
 - `metadatas` - The metadata to associate with the embeddings. When querying, you can filter on this metadata. Optional.
 - `documents` - The documents to associate with the embeddings. Optional.
-  
 
 **Returns**:
 
-  None
+None
 
 ### upsert
 
@@ -194,11 +186,10 @@ Update the embeddings, metadatas or documents for provided ids, or create them i
 - `embeddings` - The embeddings to add. If None, embeddings will be computed based on the documents using the embedding_function set for the Collection. Optional.
 - `metadatas` - The metadata to associate with the embeddings. When querying, you can filter on this metadata. Optional.
 - `documents` - The documents to associate with the embeddings. Optional.
-  
 
 **Returns**:
 
-  None
+None
 
 ### delete
 
@@ -213,11 +204,9 @@ Delete the embeddings based on ids and/or a where filter
 **Arguments**:
 
 - `ids` - The ids of the embeddings to delete
-- `where` - A Where type dict used to filter the delection by. E.g. `{"color" : "red", "price": 4.20}`. Optional.
+- `where` - A Where type dict used to filter the delection by. E.g. `{"$and": ["color" : "red", "price": {"$gte": 4.20}]}`. Optional.
 - `where_document` - A WhereDocument type dict used to filter the deletion by the document content. E.g. `{$contains: "some text"}`. Optional.
-  
 
 **Returns**:
 
-  None
-
+None


### PR DESCRIPTION
The examples for `where` filters were wrong - they had an implicit `$and` which we don't support. This was confusing some users. 