### PR TITLE
Update getting-started.md to reflect Pytorch 2.0+ compatibility 

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -27,7 +27,6 @@ Chroma is a database for building AI applications with embeddings. It comes with
 ```py
 pip install chromadb
 ```
-<span class="small-text em">* chromadb currently does not support Python 3.11 because of pytorch</span>
 
 </TabItem>
 <TabItem value="js" label="JavaScript">


### PR DESCRIPTION
Pytorch supports python 3.11 as of their 2.0 release. See: https://github.com/pytorch/pytorch/blob/main/RELEASE.md#release-compatibility-matrix

If there's still a compatibility issue (with certain versions conda, say) then the message should be more specific as to not be misleading.