### PR TITLE
Update embeddings.md

### DIFF
--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -127,6 +127,7 @@ openai_ef = embedding_functions.OpenAIEmbeddingFunction(
                 api_key="YOUR_API_KEY",
                 api_base="YOUR_API_BASE_PATH",
                 api_type="azure",
+                api_version="YOUR_API_VERSION",
                 model_name="text-embedding-ada-002"
             )
 ```


### PR DESCRIPTION
Without "api_version" will raise an error like this: "MyProjectPath/openai/api_resources/abstract/engine_api_resource.py", line 37, in class_url
    raise error.InvalidRequestError(
TypeError: __init__() missing 1 required positional argument: 'param'

Corresponding code:
            if not api_version:
                raise error.InvalidRequestError(
                    "An API version is required for the Azure API type."
                )

Please take a look ~