### PR TITLE
[DOC]: Document Environment Variable Option for Telemetry Opt-out

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,7 +4,7 @@ title: "☁️ Deployment"
 ---
 
 :::caution Alpha Status
-Chroma Server is currently in Alpha. We are working hard to move Chroma from a in-memory single-process oriented library to a distributed production-grade DB!
+Chroma Server is currently in Alpha. We are working hard to move Chroma from an in-memory single-process oriented library to a distributed production-grade DB!
 - [x] Alpha <- Currently
 - [ ] Technical Preview - ~1 month away, powered by a completely new backend
 - [ ] Full production
@@ -21,9 +21,9 @@ provided a very simple AWS CloudFormation template to experiment with
 deploying Chroma to EC2 on AWS.
 
 ## Hosted Chroma
-We want to offer hosted Chroma and we need your help. 
+We want to offer hosted Chroma, and we need your help. 
 
-Fill out the survey to jump the waitlist. Coming Q3 2023.
+Fill out the survey to jump the wait-list. Coming Q3 2023.
 
 [📝 30 second survey](https://airtable.com/shrOAiDUtS2ILy5vZ)
 
@@ -43,7 +43,7 @@ authenticating proxy.
 
 :warning: By default, this template saves all data on a single
 volume. When you delete or replace it, the data will disappear. For
-serious production use (with high availability, backups, etc) please
+serious production use (with high availability, backups, etc.) please
 read and understand the CloudFormation template and use it as a basis
 for what you need, or reach out to the Chroma team for assistance.
 
@@ -161,4 +161,4 @@ unless you've taken a snapshot or otherwise backed it up.
 
 ### Troubleshooting
 
-If you get an error saying `No default VPC for this user` when creating `ChromaInstanceSecurityGroup`, head to [AWS VPC section]( https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#vpcs) and create deafault VPC for your user
+If you get an error saying `No default VPC for this user` when creating `ChromaInstanceSecurityGroup`, head to [AWS VPC section]( https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#vpcs) and create a default VPC for your user.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -39,7 +39,7 @@ ANONYMIZED_TELEMETRY=False
 We will only track usage details that help us make product decisions, specifically:
 
 - Chroma version and environment
-- Usage of embedding functions that ship with Chroma and and aggregated usage of custom embeddings (we collect no information about the custom embeddings themselves)
+- Usage of embedding functions that ship with Chroma and aggregated usage of custom embeddings (we collect no information about the custom embeddings themselves)
 - Collection commands. We track the anonymized uuid of a collection as well as the number of items
   - `add`
   - `update`

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -13,11 +13,25 @@ We use this information to help us understand how Chroma is used, to help us pri
 
 ## **Opting out**
 
-Set `anonymized_telemetry` in your clients settings to `false` to opt out of telemetry.
+If you prefer to opt out of telemetry, you can do this in two ways.
+
+###### In Client Code
+
+Set `anonymized_telemetry` to `false` in your client's settings:
 
 ```python
 from chromadb.config import Settings
 client = chromadb.Client(Settings(anonymized_telemetry=False))
+```
+
+###### In Chroma's Backend Using Environment Variables
+
+Set `ANONYMIZED_TELEMETRY` to `False` in your shell or server environment.
+
+If you are running Chroma on your local computer with `docker-compose` you can set this value in an `.env` file placed in the same directory as the `docker-compose.yml` file:
+
+```
+ANONYMIZED_TELEMETRY=False
 ```
 
 ## **What do you track?**


### PR DESCRIPTION
I added some documentation for the `ANONYMIZED_TELEMETRY` environment variable in `docs/telemetry.md` and fixed a few spelling, punctuation, and grammar issues I noticed while I was at it.

I'm happy to rephrase anything if desired.