### PR TITLE
DOC: Removed double quotes from the example code snippet for createCollection in Client.md file.

### DIFF
--- a/docs/js_reference/Client.md
+++ b/docs/js_reference/Client.md
@@ -47,7 +47,7 @@ If there is an issue creating the collection.
 const collection = await client.createCollection({
   name: "my_collection",
   metadata: {
-    "description": "My first collection"
+    description: "My first collection"
   }
 });
 ```
@@ -152,7 +152,7 @@ If there is an issue getting or creating the collection.
 const collection = await client.getOrCreateCollection({
   name: "my_collection",
   metadata: {
-    "description": "My first collection"
+    description: "My first collection"
   }
 });
 ```


### PR DESCRIPTION
const collection = await client.createCollection({
  name: "my_collection",
  metadata: {
    "description": "My first collection"
  }
});

In above code snippet, the JavaScript object of `metadata` property has a `"description"` property, which ideally should be written as `description` without the "" (double quotes).

Thus, this double quotes is `removed` from the Client.md file.