### PR TITLE
[ENH]: REST API docs reference

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -7,6 +7,8 @@ title: "📖 API Cheatsheet"
 
 :::note
 This is a quick cheatsheet of the API. For full API docs, refer to the JS and Python docs in the sidebar.
+
+REST API docs can be viewed at http://localhost:8000/docs (the URL may vary depending on where and how you run the Chroma server).
 :::
 
 ---


### PR DESCRIPTION
Added reference to the REST API docs in the API cheatsheet

Refs: chroma-core/chroma#1322

@jeffchuber, wdyt? Maybe we can put this in a more prominent place than API cheatsheet?