### PR TITLE
Conforming to the new definition of Embeddings as per migration log 0.4.16.

### DIFF
--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -316,7 +316,7 @@ You can create your own embedding function to use with Chroma, it just needs to 
 from chromadb import Documents, EmbeddingFunction, Embeddings
 
 class MyEmbeddingFunction(EmbeddingFunction):
-    def __call__(self, texts: Documents) -> Embeddings:
+    def __call__(self, input: D) -> Embeddings:
         # embed the documents somehow
         return embeddings
 ```


### PR DESCRIPTION
As per the new migration log [link](https://docs.trychroma.com/migration#migration-to-0416---november-7-2023), the custom embedding function should also conform to its new definition. So we might need to update the documentation which follows the function definition on the lines of the new update:  
```py
Embeddable = Union[Documents, Images]
D = TypeVar("D", bound=Embeddable, contravariant=True)

class EmbeddingFunction(Protocol[D]):
    def __call__(self, input: D) -> Embeddings:
        ...
