### PR TITLE
[Docs] Update Authentication to show how to change header schema for server

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -853,12 +853,21 @@ Current implementation of static API token auth supports only ENV based tokens.
 
 ##### Running the Server
 
-Set the following environment variables:
+Set the following environment variables to use `Authorization: Bearer test-token` to be your authentication header.
 
 ```bash
 export CHROMA_SERVER_AUTH_CREDENTIALS="test-token"
 export CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER="chromadb.auth.token.TokenConfigServerAuthCredentialsProvider"
 export CHROMA_SERVER_AUTH_PROVIDER="chromadb.auth.token.TokenAuthServerProvider"
+```
+
+to use `X-Chroma-Token: test-token` type of authentication header you can set an additional environment variable.
+
+```bash
+export CHROMA_SERVER_AUTH_CREDENTIALS="test-token"
+export CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER="chromadb.auth.token.TokenConfigServerAuthCredentialsProvider"
+export CHROMA_SERVER_AUTH_PROVIDER="chromadb.auth.token.TokenAuthServerProvider"
+export CHROMA_SERVER_AUTH_TOKEN_TRANSPORT_HEADER="X_CHROMA_TOKEN"
 ```
 
 <Tabs queryString groupId="lang" className="hideTabSwitcher">


### PR DESCRIPTION
When using the docs it is not evident or clear how someone can define with Authentication header schema will be applied on boot. Some integrations may allow a `Bearer` token but the docs outline how both `Authentication: Bearer xxx` and `X-Chroma-Token: xxx` are possible.

Setting the optional `CHROMA_SERVER_AUTH_TOKEN_TRANSPORT_HEADER='X_CHROMA_TOKEN'` seems to enable this ability with the default being `Authentication: Bearer xxx`.

<img width="757" alt="Screen Shot 2023-11-20 at 9 43 51 PM" src="https://github.com/chroma-core/docs/assets/16845892/3a5e24f0-b49f-48cc-a0da-ea50695b85ac">
