### PR TITLE
DOC: Add MemGPT integration

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -16,6 +16,7 @@ We welcome pull requests to add new Integrations to the community.
 |--------------|-----------|---------------|
 | [🦜️🔗 Langchain](/integrations/langchain) | ✅  | ✅ |
 | [🦙 LlamaIndex](/integrations/llama-index) | ✅  | :soon: |
+| [📚🦙 MemGPT](/integrations/memgpt) | ✅  |  |
 
 *Coming soon* - integrations with LangSmith, JinaAI, Braintrust and more.
 

--- a/docs/integrations/memgpt.md
+++ b/docs/integrations/memgpt.md
@@ -22,5 +22,5 @@ You can configure Chroma with both the HTTP and persistent storage client via `m
 ? Select default human: cs_phd
 ? Select storage backend for archival data: chroma
 ? Select chroma backend: persistent
-? Enter persistent storage location: /Users/sarahwooders/.memgpt/config/chroma
+? Enter persistent storage location: /path/to/your/.memgpt/config/chroma
 ```

--- a/docs/integrations/memgpt.md
+++ b/docs/integrations/memgpt.md
@@ -1,0 +1,26 @@
+---
+slug: /integrations/memgpt
+title: 📚🦙 MemGPT
+---
+
+MemGPT enables LLMs to manage their own memory and overcome limited context windows. You can use MemGPT to create perpetual chatbots that learn about you and modify their own personalities over time. You can connect MemGPT to your own local filesystems and databases, as well as connect MemGPT to your own tools and APIs. The MemGPT + Chroma integration allows you to back MemGPT's memory system with Chroma.
+
+## MemGPT + Chroma
+
+To enable the Chroma storage backend in MemGPT, install the dependencies with: 
+```
+pip install `pymemgpt[chroma]`
+```
+You can configure Chroma with both the HTTP and persistent storage client via `memgpt configure`. You will need to specify either a persistent storage path or host/port dependending on your client choice. The example below shows how to configure Chroma with local persistent storage: 
+```
+? Select LLM inference provider: openai
+? Override default endpoint: https://api.openai.com/v1
+? Select default model (recommended: gpt-4): gpt-4
+? Select embedding provider: openai
+? Select default preset: memgpt_chat
+? Select default persona: sam_pov
+? Select default human: cs_phd
+? Select storage backend for archival data: chroma
+? Select chroma backend: persistent
+? Enter persistent storage location: /Users/sarahwooders/.memgpt/config/chroma
+```


### PR DESCRIPTION
Added notes on Chroma backend for MemGPT.

Chroma on the MemGPT documentation: https://memgpt.readthedocs.io/en/latest/storage/#lancedb