### PR TITLE
docs: add link to Jina documentation

### DIFF
--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -19,6 +19,7 @@ Chroma provides lightweight wrappers around popular embedding providers, making 
 | [Hugging Face](/embeddings/hugging-face) | ✅  | ➖ |
 | [Instructor](/embeddings/instructor) | ✅  | ➖ |
 | [Hugging Face Embedding Server](/embeddings/hugging-face-embedding-server) | ✅  | ✅ |
+| [Jina AI](/embeddings/jinaai) | ✅  | ✅ |
 
 We welcome pull requests to add new Embedding Functions to the community.
 


### PR DESCRIPTION
The Jina documentation is hard to discover