### PR TITLE
DOC: fix example for embeddings fn protocol

### DIFF
--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -116,7 +116,7 @@ You can create your own embedding function to use with Chroma, it just needs to 
 from chromadb import Documents, EmbeddingFunction, Embeddings
 
 class MyEmbeddingFunction(EmbeddingFunction):
-    def __call__(self, texts: Documents) -> Embeddings:
+    def __call__(self, input: Documents) -> Embeddings:
         # embed the documents somehow
         return embeddings
 ```


### PR DESCRIPTION
if doing something like the example shown [here](https://docs.trychroma.com/embeddings?lang=py#custom-embedding-functions)
```
class OpenAIEmbeddingFunction(EmbeddingFunction):
    def __call__(self, texts: Documents) -> Embeddings:
        return create_openai_embeddings(input)
```
you'd get
```
  File "/Users/nate/micromamba/envs/marvin/lib/python3.11/site-packages/chromadb/api/types.py", line 210, in validate_embedding_function
    raise ValueError(
ValueError: Expected EmbeddingFunction.__call__ to have the following signature: odict_keys(['self', 'input']), got odict_keys(['self', 'texts'])
```

while using
```
» pip list | rg chroma
chroma-hnswlib                           0.7.3
chromadb                                 0.4.20
```

the[ link to migration docs](https://docs.trychroma.com/migration#migration-to-0416---november-7-2023) displayed in the error was helpful 👏🏼 

just as a data point, i actually prefer how it was before (i.e. `texts`) because `input` is a python keyword