### PR TITLE
Add link to PHP (Laravel) client in intro.md

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -75,6 +75,7 @@ Continue with the full [getting started guide](./getting-started.md).
 | Rust | ➖ | ✅ [from @Anush008](https://crates.io/crates/chromadb) |
 | Elixir | ➖ | ✅ [from @3zcurdia](https://hex.pm/packages/chroma/) |
 | Dart | ➖ | ✅ [from @davidmigloz](https://pub.dev/packages/chromadb) |
+| PHP | ➖ | ✅ [from @HelgeSverre](https://github.com/helgeSverre/chromadb)                                                            |
 | Other?       | ❓    | ❓            |
 
 <br/>


### PR DESCRIPTION
Hey ChromaDB Team.

I wrote a **PHP** Client for the REST API, and added it to the "[Language Support](https://docs.trychroma.com/#language-support)" section in the Intro docs.

- Packagist: https://packagist.org/packages/helgesverre/chromadb
- GitHub: https://github.com/HelgeSverre/chromadb/

Installable with Composer using:

```shell
composer require helgesverre/chromadb
```

Supports regular PHP and registers a Facade and service provider for Laravel developers.