### PR TITLE
fix: Removed single quote Docker env vars for auth examples

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -802,8 +802,8 @@ Set the following environment variables:
 
 ```bash
 export CHROMA_SERVER_AUTH_CREDENTIALS_FILE="server.htpasswd"
-export CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER='chromadb.auth.providers.HtpasswdFileServerAuthCredentialsProvider'
-export CHROMA_SERVER_AUTH_PROVIDER='chromadb.auth.basic.BasicAuthServerProvider'
+export CHROMA_SERVER_AUTH_CREDENTIALS_PROVIDER="chromadb.auth.providers.HtpasswdFileServerAuthCredentialsProvider"
+export CHROMA_SERVER_AUTH_PROVIDER="chromadb.auth.basic.BasicAuthServerProvider"
 ```
 
 And run the server as normal:


### PR DESCRIPTION
Refs chroma-core/chroma#1601