### PR TITLE
DOC: Fix Python syntax in code snippets and JS link

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -19,7 +19,7 @@ Chroma currently maintains 1st party clients for Python and Javascript. For othe
 |              | Client | Collection |
 |--------------|-----------|---------------|
 | Python | [Client](/reference/Client) | [Collection](/reference/Collection) |
-| Javascript | [Client](/js_reference/Client)   | [Collection](/reference/Collection) |
+| Javascript | [Client](/js_reference/Client)   | [Collection](/js_reference/Collection) |
 
 *** 
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -522,14 +522,14 @@ When using get or query you can use the include parameter to specify which data 
 ```python
 
 # Only get documents and ids
-collection.get({
-    include: [ "documents" ]
-})
+collection.get(
+    include=[ "documents" ]
+)
 
-collection.query({
-    queryEmbeddings: [[11.1, 12.1, 13.1],[1.1, 2.3, 3.2], ...],
-    include: [ "documents" ]
-})
+collection.query(
+    query_embeddings=[[11.1, 12.1, 13.1],[1.1, 2.3, 3.2], ...],
+    include=[ "documents" ]
+)
 ```
 
 ### Using Where filters


### PR DESCRIPTION
- In docs/usage-guide.md, the code snippets used javascript syntax for Python code snippets.
- In docs/api/index.md, the Javascript Collection pointed to Python documentation.