### PR TITLE
Update hugging-face-embedding-server.md

### DIFF
--- a/docs/embeddings/hugging-face-embedding-server.md
+++ b/docs/embeddings/hugging-face-embedding-server.md
@@ -26,7 +26,7 @@ docker compose -f examples/server_side_embeddings/huggingface/docker-compose.yml
 or
 
 ```bash
-docker run -p 8001:80 -d -rm --name huggingface-embedding-server ghcr.io/huggingface/text-embeddings-inference:cpu-0.3.0 --model-id BAAI/bge-small-en-v1.5 --revision -main
+docker run -p 8001:80 -d --rm --name huggingface-embedding-server ghcr.io/huggingface/text-embeddings-inference:cpu-0.3.0 --model-id BAAI/bge-small-en-v1.5 --revision -main
 ```
 
 :::note


### PR DESCRIPTION
Fix typo in Docker run command

Corrected the Docker run command to remove the typo in the --rm flag placement. The corrected command now properly starts the huggingface-embedding-server container with the specified image and parameters.