### PR TITLE
Fix collection.query example in api-reference

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -239,9 +239,9 @@ await collection.peek()
 
 // do nearest neighbor search to find similar embeddings or documents, supports filtering
 await collection.query({
-    queryEmbeddings=[[1.1, 2.3, 3.2], [5.1, 4.3, 2.2]],
-    nResults=2,
-    where={"style": "style2"}
+    queryEmbeddings: [[1.1, 2.3, 3.2], [5.1, 4.3, 2.2]],
+    nResults: 2,
+    where: {"style": "style2"}
 })
 
 // delete items


### PR DESCRIPTION
It should be colon separated key value pairs, not equal sign