### PR TITLE
[DOC]: Count collections in Client API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ yarn-debug.log*
 yarn-error.log*
 
 .tmp
+.idea/

--- a/docs/reference/Client.md
+++ b/docs/reference/Client.md
@@ -232,6 +232,26 @@ Delete a collection with the given name.
   client.delete_collection("my_collection")
   ```
 
+## count\_collections
+
+```python
+def count_collections() -> int
+```
+
+Count the number of collections.
+
+**Returns**:
+
+- `int` - The number of collections.
+
+
+**Examples**:
+
+```python
+client.count_collections()
+# 1
+```
+
 ## reset
 
 ```python


### PR DESCRIPTION
This is just a partial update to add `count_collections` method. Running `scripts/pythonDocs.sh` generates a much larger diff (incl. CloudClient)
