### PR TITLE
Add MindsDB to integrations list and initial docs page

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -20,6 +20,7 @@ We welcome pull requests to add new Integrations to the community.
 | [🔭 OpenLLMetry](/integrations/openllmetry) | ✅     | :soon: |
 | [🎈 Streamlit](/integrations/streamlit) | ✅     | ➖ |
 | [💙 Haystack](/integrations/haystack) | ✅     | ➖ |
+| [MindsDB](/integrations/mindsdb) | ✅     | ✅ |
 
 *Coming soon* - integrations with LangSmith, JinaAI, and more.
 

--- a/docs/integrations/mindsdb.md
+++ b/docs/integrations/mindsdb.md
@@ -1,0 +1,35 @@
+# MindsDB
+
+MindsDB is the platform for customizing AI from enterprise data. MindsDB integrates with numerous data sources, including [Chroma](https://docs.mindsdb.com/integrations/vector-db-integrations/chromadb).
+
+### Connect to Chroma using SQL
+
+
+The required arguments to establish a connection are:
+
+*    `host`: the host name or IP address of the Chroma instance.
+*    `port`: the TCP/IP port of the Chroma instance.
+*    `persist_directory`: [Optional] the directory to use for persisting data. This will create an in-memory ChromaDB instance.
+
+To connect to a remote ChromaDB instance, the following CREATE DATABASE can be used:
+
+```sql
+CREATE DATABASE chromadb_datasource
+WITH ENGINE = 'chromadb'
+PARAMETERS = {
+    "host": "YOUR_HOST",
+    "port": YOUR_PORT
+}
+```
+
+Alternateively, to connect to an in-memory ChromaDB instance, the following CREATE DATABASE can be used:
+
+```sql
+CREATE DATABASE chromadb_datasource
+WITH ENGINE = "chromadb",
+PARAMETERS = {
+    "persist_directory": "YOUR_PERSIST_DIRECTORY"
+}
+```
+
+For more informations and usage examples check [MindsDB Chroma docs](https://docs.mindsdb.com/integrations/vector-db-integrations/chromadb).

--- a/sidebars.js
+++ b/sidebars.js
@@ -69,6 +69,7 @@ const sidebars = {
         'integrations/openllmetry',
         'integrations/streamlit',
         'integrations/haystack',
+        'integrations/mindsdb'
       ],
     },
   ],


### PR DESCRIPTION
This PR includes MindsDB to the Integrations List and adds an initial docs  page for connecting MindsDB to Chroma using SQL
![Screenshot from 2024-04-19 16-26-28](https://github.com/chroma-core/docs/assets/7192539/0e97fa57-b8d2-4e32-9d24-48edc9ba98f0)
Let me know if something else is needed :raised_hands: 